### PR TITLE
Add PHP 8.5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         }
     ],
     "require": {
+        "php": "^8.1",
         "spomky-labs/cbor-php": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- Added explicit PHP ^8.1 version constraint to composer.json to support PHP 8.5

## Related
- [ED-6119](https://ebankp.atlassian.net/browse/ED-6119)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ED-6119]: https://ebankp.atlassian.net/browse/ED-6119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added an explicit PHP version requirement (^8.1) in composer.json to enable PHP 8.5 support and block installs on older PHP versions. Addresses ED-6119.

<sup>Written for commit 675d3260e21320acdc5955146e6d6e5636052ef9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

