### PR TITLE
Fix deprecated (integer) cast for PHP 8.x

### DIFF
--- a/src/Base58Validation.php
+++ b/src/Base58Validation.php
@@ -29,7 +29,7 @@ class Base58Validation extends Validation
         while (bccomp($dec, 0) == 1)
         {
             $dv     = (string)bcdiv($dec, "16", 0);
-            $rem    = (integer)bcmod($dec, "16");
+            $rem    = (int)bcmod($dec, "16");
             $dec    = $dv;
             $return = $return . $chars[$rem];
         }
@@ -74,7 +74,7 @@ class Base58Validation extends Validation
         while (bccomp($hex, 0) == 1)
         {
             $dv     = (string)bcdiv($hex, "58", 0);
-            $rem    = (integer)bcmod($hex, "58");
+            $rem    = (int)bcmod($hex, "58");
             $hex    = $dv;
             $return = $return . static::$base58Dictionary[$rem];
         }

--- a/src/Utils/Sha3.php
+++ b/src/Utils/Sha3.php
@@ -368,7 +368,7 @@ final class Sha3
      * @param int $length (optional)
      * @return string
      */
-    private static function ourSubstr($str, $start = 0, $length = null)
+    private static function ourSubstr(string $str, int $start = 0, ?int $length = null): string
     {
         // Premature optimization: cache the function_exists() result
         static $exists = null;


### PR DESCRIPTION
## Summary

Fix PHP 8.x deprecations to ensure compatibility with PHP 8.4 and PHP 8.5.

## Changes

### Base58Validation.php
- Line 32: `(integer)bcmod($dec, "16")` → `(int)bcmod($dec, "16")`  
- Line 77: `(integer)bcmod($hex, "58")` → `(int)bcmod($hex, "58")`

The `(integer)` cast syntax is deprecated in PHP 8.0+ and will be removed in PHP 9.

### Sha3.php
- Line 371: Added explicit type declarations to `ourSubstr()` method
- Changed: `ourSubstr($str, $start = 0, $length = null)`
- To: `ourSubstr(string $str, int $start = 0, ?int $length = null): string`

This fixes the implicit nullable deprecation warning in PHP 8.4+.

## Related

- ebankp issue: [ED-6438](https://ebankp.atlassian.net/browse/ED-6438)

[ED-6438]: https://ebankp.atlassian.net/browse/ED-6438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ