### PR TITLE
Upgrade cbor-php from ^2.0 to ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "spomky-labs/cbor-php": "^2.0"
+        "spomky-labs/cbor-php": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~8.0"

--- a/src/Validation/TADA.php
+++ b/src/Validation/TADA.php
@@ -2,9 +2,6 @@
 
 namespace Merkeleon\PhpCryptocurrencyAddressValidation\Validation;
 
-use Merkeleon\PhpCryptocurrencyAddressValidation\Base58Validation;
-use Merkeleon\PhpCryptocurrencyAddressValidation\Utils\Bech32Decoder;
-use Merkeleon\PhpCryptocurrencyAddressValidation\Utils\Bech32Exception;
 use CBOR\Decoder;
 use CBOR\OtherObject;
 use CBOR\Tag;


### PR DESCRIPTION
## Summary

- Upgrades `spomky-labs/cbor-php` dependency from `^2.0` to `^3.0`
- Updates `ADA.php` (Cardano address validation) for cbor-php v3 API breaking changes
- Removes unused CBOR imports from `TADA.php`

## Why

The ebankp project requires `web-auth/webauthn-framework 5.3.x-dev` which needs `cbor-php ^3.0`. This conflicts with the current `^2.0` constraint in this package.

## API changes handled

| cbor-php v2 | cbor-php v3 |
|---|---|
| `Tag\TagObjectManager` | `Tag\TagManager` |
| `Tag\PositiveBigIntegerTag` | `Tag\UnsignedBigIntegerTag` |
| `$object->getNormalizedData()` | `$object->normalize()` |
| `$normalizedData[0]` is `ByteStringObject` | `$normalizedData[0]` is `GenericTag` (unwrap with `->getValue()`) |

## Test plan

- [ ] Verify ADA (Cardano) v1 address validation still works
- [ ] Verify ADA bech32 address validation still works
- [ ] Verify TADA (Cardano testnet) address validation still works
- [ ] Run `composer update` in ebankp to confirm dependency resolution

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded cbor-php to ^3.0 and updated Cardano (ADA) address validation to the v3 API. This resolves the dependency conflict with web-auth/webauthn-framework in ebankp.

- **Dependencies**
  - Bump spomky-labs/cbor-php to ^3.0.

- **Refactors**
  - ADA.php: switch to TagManager + UnsignedBigIntegerTag, use normalize(), unwrap GenericTag to ByteStringObject, and update CRC calculation.
  - TADA.php: remove unused imports.

<sup>Written for commit ad0316a22ac976edd8599a869bfdb19db199bd41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

